### PR TITLE
Add a mandatory ispe property to the alpha image

### DIFF
--- a/src/boxes.rs
+++ b/src/boxes.rs
@@ -372,7 +372,7 @@ impl MpegBox for IspeBox {
 #[derive(Debug, Clone)]
 pub struct IpmaEntry {
     pub item_id: u16,
-    pub prop_ids: ArrayVec<u8, 3>,
+    pub prop_ids: ArrayVec<u8, 4>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Aviffy {
             }
             ipma_entries.push(IpmaEntry {
                 item_id: alpha_image_id,
-                prop_ids: [av1c_prop, auxc_prop, pixi_1].iter().copied().collect(),
+                prop_ids: [ispe_prop, av1c_prop, auxc_prop, pixi_1].iter().copied().collect(),
             });
 
             // Use interleaved color and alpha, with alpha first.


### PR DESCRIPTION
This requires increasing the capacity of the prop_ids ArrayVec in struct
IpmaEntry from 3 to 4.

Fix https://github.com/kornelski/avif-serialize/issues/3