### PR TITLE
Mark av1C properties as essential

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avif-serialize"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Kornel Lesiński <kornel@geekhood.net>"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ impl Aviffy {
         let alpha_image_id = 2;
         let high_bitdepth = depth_bits >= 10;
         let twelve_bit = depth_bits >= 12;
+        const ESSENTIAL_BIT: u8 = 0x80;
 
         image_items.push(InfeBox {
             id: color_image_id,
@@ -113,7 +114,7 @@ impl Aviffy {
         }));
         ipma_entries.push(IpmaEntry {
             item_id: color_image_id,
-            prop_ids: [ispe_prop, av1c_prop, pixi_3].iter().copied().collect(),
+            prop_ids: [ispe_prop, av1c_prop | ESSENTIAL_BIT, pixi_3].iter().copied().collect(),
         });
 
         if let Some(alpha_data) = alpha_av1_data {
@@ -161,7 +162,7 @@ impl Aviffy {
             }
             ipma_entries.push(IpmaEntry {
                 item_id: alpha_image_id,
-                prop_ids: [ispe_prop, av1c_prop, auxc_prop, pixi_1].iter().copied().collect(),
+                prop_ids: [ispe_prop, av1c_prop | ESSENTIAL_BIT, auxc_prop, pixi_1].iter().copied().collect(),
             });
 
             // Use interleaved color and alpha, with alpha first.


### PR DESCRIPTION
AVIF specification v1.0.0 Section 2.2.1. AV1 Item Configuration Property
says:
    This property shall be marked as essential.

The "shall" has been relaxed to a "should" in the current draft of the
next version of the AVIF specification:
    This property should be marked as essential.

Also bump the version to 0.7.5.