### PR TITLE
Fix the encoding of av1C properties

### DIFF
--- a/src/boxes.rs
+++ b/src/boxes.rs
@@ -464,7 +464,7 @@ impl MpegBox for AuxlBox {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Av1CBox {
-    pub seq_profile: bool,
+    pub seq_profile: u8,
     pub seq_level_idx_0: u8,
     pub seq_tier_0: bool,
     pub high_bitdepth: bool,
@@ -485,13 +485,13 @@ impl MpegBox for Av1CBox {
         let mut b = w.new_box(self.len());
         b.basic_box(*b"av1C")?;
         let flags1 =
-            (self.seq_tier_0 as u8) |
-            (self.high_bitdepth as u8) << 1 |
-            (self.twelve_bit as u8) << 2 |
-            (self.monochrome as u8) << 3 |
-            (self.chroma_subsampling_x as u8) << 4 |
-            (self.chroma_subsampling_y as u8) << 5 |
-            (self.chroma_sample_position as u8) << 6;
+            (self.seq_tier_0 as u8) << 7 |
+            (self.high_bitdepth as u8) << 6 |
+            (self.twelve_bit as u8) << 5 |
+            (self.monochrome as u8) << 4 |
+            (self.chroma_subsampling_x as u8) << 3 |
+            (self.chroma_subsampling_y as u8) << 2 |
+            (self.chroma_sample_position as u8);
 
         b.push(&[
             0x81, // marker and version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,8 @@ impl Aviffy {
         let ispe_prop = ipco.push(IpcoProp::Ispe(IspeBox { width, height }));
         // This is redundant, but Chrome wants it, and checks that it matches :(
         let av1c_prop = ipco.push(IpcoProp::Av1C(Av1CBox {
-            seq_profile: false,
-            seq_level_idx_0: 0,
+            seq_profile: if twelve_bit { 2 } else { 1 },
+            seq_level_idx_0: 31,
             seq_tier_0: false,
             high_bitdepth,
             twelve_bit,
@@ -123,14 +123,14 @@ impl Aviffy {
                 name: "",
             });
             let av1c_prop = ipco.push(boxes::IpcoProp::Av1C(Av1CBox {
-                seq_profile: false,
-                seq_level_idx_0: 0,
+                seq_profile: if twelve_bit { 2 } else { 0 },
+                seq_level_idx_0: 31,
                 seq_tier_0: false,
                 high_bitdepth,
                 twelve_bit,
                 monochrome: true,
-                chroma_subsampling_x: false,
-                chroma_subsampling_y: false,
+                chroma_subsampling_x: true,
+                chroma_subsampling_y: true,
                 chroma_sample_position: 0,
             }));
             // So pointless


### PR DESCRIPTION
Change the type of the seq_profile field of struct Av1CBox from bool to
u8 because it needs to represents 3 bits:
  unsigned int (3) seq_profile;

Reverse the order of serializing the components of 'flags1'. The first
field, seq_tier_0, should occupy the most significant bit of the byte.

Ideally the fields of the av1C property should be set to values
obtained by parsing the sequence header OBU in the AV1 bitstream. For
simplicity we set them to values that we predict rav1e will use.

In the av1C property for the color image, YUV 4:4:4 requires
seq_profile=1 for bit depth 8 or 10 and seq_profile=2 for bit depth 12.

In the av1C property for the alpha image, monochrome requires
seq_profile=0 for bit depth 8 or 10 and seq_profile=2 for bit depth 12.
chroma_subsampling_x and chroma_subsampling_y are both equal to 1 for
monochrome.

In both av1C properties, set seq_level_idx_0 to 31, which is the
"Maximum parameters" level. Empirically this level appears to be used by
rav1e.