### PR TITLE
feat(boxes): do not write the `iref` box if it is empty

### DIFF
--- a/src/boxes.rs
+++ b/src/boxes.rs
@@ -446,10 +446,19 @@ pub struct IrefBox {
 impl MpegBox for IrefBox {
     #[inline(always)]
     fn len(&self) -> usize {
+        if self.entries.is_empty() {
+            return 0;
+        }
+
         FULL_BOX_SIZE + self.entries.iter().map(|e| e.len()).sum::<usize>()
     }
 
     fn write<B: WriterBackend>(&self, w: &mut Writer<B>) -> Result<(), B::Error> {
+        // The iref box is not mandatory, skip it if empty.
+        if self.entries.is_empty() {
+            return Ok(());
+        }
+
         let mut b = w.full_box(self.len(), *b"iref", 0)?;
         for entry in &self.entries {
             entry.write(&mut b)?;


### PR DESCRIPTION
## Description

This PR proposes to only write the `iref` box if it has entries, thus restoring the behavior from v0.8.1, which was changed by 185bcbc39db8efdc4753002b6fc9a543a9c8c1d6 and modified by 075beb54d3479c6d1995084287e948728b0d2e4c. However, I am not very familiar with the format, so this might not actually make sense.

My understanding is that the usage of these boxes is specified by the ISOBMFF standard, which I unfortunately do not have access to. However I have found https://github.com/gpac/ComplianceWarden/issues/17, which seems to state that the `iref` box is not mandatory.

Additional context: I am updating a project that was using `ravif` v0.11.10, which itself was using `avif-serialize` v0.8.1. When bumping to v0.12.0 (which uses `avif-serialize` v0.8.5), that project's snapshot tests broke as they hash the resulting AVIF files (whose stability is important to avoid busting users' image cache). After some digging I found that the `iref` box was now written, due to 185bcbc39db8efdc4753002b6fc9a543a9c8c1d6.

Applying this PR results in AVIF files that are byte-for-byte identical to the ones from v0.11.10 (at least for the files I have tested). It is unclear to me whether always writing the `iref` box is necessary, or whether the old behavior could be restored (also making the files *slightly* smaller).

## Testing

The tests pass, and I have additionally tested the resulting files with [ComplianceWarden-wasm](https://gpac.github.io/ComplianceWarden-wasm/), which do not show warnings/errors about a missing `iref` box.

---

Feel free to push to this PR's branch as needed.
