### PR TITLE
Add clli and mdcv HDR metadata box support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avif-serialize"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Kornel Lesiński <kornel@geekhood.net>"]
 edition = "2021"
 license = "BSD-3-Clause"
@@ -19,6 +19,7 @@ arrayvec = "0.7.6"
 [dev-dependencies]
 mp4parse = "0.17"
 avif-parse = "1.4.0"
+zenavif-parse = { path = "/home/lilith/work/zenavif-parse" }
 
 [badges]
 maintenance = { status = "passively-maintained" }


### PR DESCRIPTION
Adds Content Light Level Information (`clli`, CEA-861.3) and Mastering Display Colour Volume (`mdcv`, SMPTE ST 2086) ISOBMFF property boxes, enabling HDR AVIF encoding.

## Changes

- `ClliBox`: 4 bytes payload — MaxCLL and MaxFALL in cd/m²
- `MdcvBox`: 24 bytes payload — 3 chromaticity primaries, white point, luminance range
- New `Aviffy` setter methods: `set_content_light_level()`, `set_mastering_display()`
- Properties are associated to the primary color image item via `ipma`
- `IpcoBox` capacity 7→9, `IpmaEntry` capacity 5→7 to accommodate new props
- 4 roundtrip tests verifying serialized boxes parse correctly

## Motivation

These boxes are required for proper HDR10/PQ AVIF files. Without them, the HDR metadata only exists in the AV1 bitstream — but per the AVIF spec, container-level properties are authoritative.